### PR TITLE
feat: Add support for the key of F

### DIFF
--- a/script.js
+++ b/script.js
@@ -260,6 +260,7 @@ const keyDisplayRanges = {
   'C': { startNote: 'C3', endNoteBase: 'E' },
   'D': { startNote: 'D3', endNoteBase: 'F#' },
   'E': { startNote: 'E3', endNoteBase: 'G#' },
+  'F': { startNote: 'F3', endNoteBase: 'A' },
 }
 
 const flexKeymaps = {
@@ -384,6 +385,14 @@ const flexKeymaps = {
       "a":{note:'E',octave:4},"s":{note:'F',octave:4},"d":{note:'G',octave:4},"f":{note:'A',octave:4},"g":{note:'Bb',octave:4},"h":{note:'C',octave:4},"j":{note:'D',octave:5},"k":{note:'E',octave:5},"l":{note:'F',octave:5},";":{note:'G',octave:5},
       "q":{note:'E',octave:5},"w":{note:'F',octave:5},"e":{note:'G',octave:5},"r":{note:'A',octave:5},"t":{note:'Bb',octave:5},"y":{note:'C',octave:6},"u":{note:'D',octave:6},"i":{note:'E',octave:6},"o":{note:'F',octave:6},"p":{note:'G',octave:6},
       "1":{note:'E',octave:6},"2":{note:'F',octave:6},"3":{note:'G',octave:6},"4":{note:'A',octave:6},"5":{note:'Bb',octave:6},"6":{note:'C',octave:7},"7":{note:'D',octave:7},"8":{note:'E',octave:7},"9":{note:'F',octave:7},"0":{note:'G',octave:7}
+    }
+  },
+  'F': {
+    'Major': {
+      'z':{note:'F',octave:3},'x':{note:'G',octave:3},'c':{note:'A',octave:3},'v':{note:'Bb',octave:3},'b':{note:'C',octave:4},'n':{note:'D',octave:4},'m':{note:'E',octave:4},',':{note:'F',octave:4},'.':{note:'G',octave:4},'/':{note:'A',octave:4},
+      'a':{note:'F',octave:4},'s':{note:'G',octave:4},'d':{note:'A',octave:4},'f':{note:'Bb',octave:4},'g':{note:'C',octave:5},'h':{note:'D',octave:5},'j':{note:'E',octave:5},'k':{note:'F',octave:5},'l':{note:'G',octave:5},';':{note:'A',octave:5},
+      'q':{note:'F',octave:5},'w':{note:'G',octave:5},'e':{note:'A',octave:5},'r':{note:'Bb',octave:5},'t':{note:'C',octave:6},'y':{note:'D',octave:6},'u':{note:'E',octave:6},'i':{note:'F',octave:6},'o':{note:'G',octave:6},'p':{note:'A',octave:6},
+      '1':{note:'F',octave:6},'2':{note:'G',octave:6},'3':{note:'A',octave:6},'4':{note:'Bb',octave:6},'5':{note:'C',octave:7},'6':{note:'D',octave:7},'7':{note:'E',octave:7},'8':{note:'F',octave:7},'9':{note:'G',octave:7},'0':{note:'A',octave:7}
     }
   }
 };


### PR DESCRIPTION
This commit adds support for the key of F to the virtual keyboard.

- Adds 'F' to the `keyDisplayRanges` to correctly display the keyboard layout starting from F.
- Adds the F Major scale keybindings to `flexKeymaps` for the "Flex" layout.